### PR TITLE
Update available models to current off-frontier versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ POST /api/adversarial/stream  # Streaming responses
 Body: { 
   "question": "Your research question",
   "roles": [
-    { "id": "advocate", "model": "gpt-5.1", ... },
-    { "id": "challenger", "model": "gpt-5.1", ... },
-    { "id": "arbiter", "model": "gpt-5.1", ... }
+    { "id": "advocate", "model": "gpt-5.3", ... },
+    { "id": "challenger", "model": "gpt-5.3", ... },
+    { "id": "arbiter", "model": "gpt-5.3", ... }
   ],
   "turnLimit": "smart" // or "1", "2", "3"
 }
@@ -208,7 +208,7 @@ AI_INTEGRATIONS_OPENROUTER_API_KEY=sk-or-...
 Edit `backend/src/config.js`:
 ```javascript
 councilMembers: [
-  { id: 'new-model', name: 'New Model', model: 'gpt-5.1', provider: 'Provider Name', color: '#hex' },
+  { id: 'new-model', name: 'New Model', model: 'gpt-5.3', provider: 'Provider Name', color: '#hex' },
   // ...
 ]
 ```

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -24,48 +24,36 @@ export const config = {
     },
   },
   
-  defaultModel: 'gpt-5.1',
-  chairmanModel: 'gpt-5.1',
-  
+  defaultModel: 'gpt-5.3',
+  chairmanModel: 'gpt-5.3',
+
   availableModels: [
-    { id: 'gpt-5.2', name: 'GPT-5.2', provider: 'OpenAI', providerKey: 'openai', description: 'Latest flagship model', color: '#10B981' },
-    { id: 'gpt-5.1', name: 'GPT-5.1', provider: 'OpenAI', providerKey: 'openai', description: 'High-performance model', color: '#8B5CF6' },
-    { id: 'gpt-5', name: 'GPT-5', provider: 'OpenAI', providerKey: 'openai', description: 'Balanced performance', color: '#3B82F6' },
+    { id: 'gpt-5.3', name: 'GPT-5.3', provider: 'OpenAI', providerKey: 'openai', description: 'Flagship reasoning model', color: '#10B981' },
+    { id: 'gpt-5.2', name: 'GPT-5.2', provider: 'OpenAI', providerKey: 'openai', description: 'High-performance model', color: '#8B5CF6' },
+    { id: 'gpt-5.1', name: 'GPT-5.1', provider: 'OpenAI', providerKey: 'openai', description: 'Balanced performance', color: '#3B82F6' },
     { id: 'gpt-5-mini', name: 'GPT-5 Mini', provider: 'OpenAI', providerKey: 'openai', description: 'Fast and efficient', color: '#F59E0B' },
     { id: 'gpt-5-nano', name: 'GPT-5 Nano', provider: 'OpenAI', providerKey: 'openai', description: 'Ultra-fast lightweight', color: '#84CC16' },
-    { id: 'gpt-4.1', name: 'GPT-4.1', provider: 'OpenAI', providerKey: 'openai', description: 'Previous generation flagship', color: '#EF4444' },
-    { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'OpenAI', providerKey: 'openai', description: 'Efficient GPT-4.1', color: '#F97316' },
-    { id: 'gpt-4o', name: 'GPT-4o', provider: 'OpenAI', providerKey: 'openai', description: 'Optimized GPT-4', color: '#EC4899' },
-    { id: 'gpt-4o-mini', name: 'GPT-4o Mini', provider: 'OpenAI', providerKey: 'openai', description: 'Fast GPT-4o', color: '#F472B6' },
-    { id: 'o4-mini', name: 'O4 Mini', provider: 'OpenAI', providerKey: 'openai', description: 'Compact reasoning', color: '#A855F7' },
-    { id: 'o3', name: 'O3', provider: 'OpenAI', providerKey: 'openai', description: 'Advanced reasoning model', color: '#14B8A6' },
-    { id: 'o3-mini', name: 'O3 Mini', provider: 'OpenAI', providerKey: 'openai', description: 'Fast reasoning', color: '#6366F1' },
-    
-    { id: 'claude-opus-4-5', name: 'Claude Opus 4.5', provider: 'Anthropic', providerKey: 'anthropic', description: 'Most capable, complex reasoning', color: '#D97706' },
+
+    { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', provider: 'Anthropic', providerKey: 'anthropic', description: 'Most capable, complex reasoning', color: '#D97706' },
     { id: 'claude-sonnet-4-5', name: 'Claude Sonnet 4.5', provider: 'Anthropic', providerKey: 'anthropic', description: 'Balanced performance and speed', color: '#EA580C' },
     { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', provider: 'Anthropic', providerKey: 'anthropic', description: 'Fastest and most compact', color: '#DC2626' },
-    { id: 'claude-opus-4-1', name: 'Claude Opus 4.1', provider: 'Anthropic', providerKey: 'anthropic', description: 'Earlier flagship version', color: '#B45309' },
-    
-    { id: 'gemini-3-pro-preview', name: 'Gemini 3 Pro', provider: 'Google', providerKey: 'gemini', description: 'Most powerful for agentic workflows', color: '#4285F4' },
-    { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash', provider: 'Google', providerKey: 'gemini', description: 'Hybrid reasoning model', color: '#34A853' },
+
+    { id: 'gemini-3-pro', name: 'Gemini 3 Pro', provider: 'Google', providerKey: 'gemini', description: 'Most powerful for agentic workflows', color: '#4285F4' },
+    { id: 'gemini-3-flash', name: 'Gemini 3 Flash', provider: 'Google', providerKey: 'gemini', description: 'Fast hybrid reasoning model', color: '#34A853' },
     { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'Google', providerKey: 'gemini', description: 'Excels at coding and reasoning', color: '#FBBC04' },
     { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', provider: 'Google', providerKey: 'gemini', description: 'Fast general purpose', color: '#EA4335' },
-    
-    { id: 'meta-llama/llama-4-maverick', name: 'Llama 4 Maverick', provider: 'Meta (OpenRouter)', providerKey: 'openrouter', description: '400B MoE, multimodal (FREE)', color: '#0668E1' },
-    { id: 'meta-llama/llama-4-scout', name: 'Llama 4 Scout', provider: 'Meta (OpenRouter)', providerKey: 'openrouter', description: 'Latest Llama reasoning (FREE)', color: '#0866FF' },
-    { id: 'meta-llama/llama-3.3-70b-instruct', name: 'Llama 3.3 70B', provider: 'Meta (OpenRouter)', providerKey: 'openrouter', description: 'High-performance open model', color: '#1877F2' },
-    { id: 'deepseek/deepseek-chat-v3-0324', name: 'DeepSeek V3', provider: 'DeepSeek (OpenRouter)', providerKey: 'openrouter', description: 'Strong reasoning and coding', color: '#00D4AA' },
-    { id: 'deepseek/deepseek-r1', name: 'DeepSeek R1', provider: 'DeepSeek (OpenRouter)', providerKey: 'openrouter', description: 'Reasoning specialist', color: '#00B894' },
-    { id: 'qwen/qwen3-32b', name: 'Qwen 3 32B', provider: 'Qwen (OpenRouter)', providerKey: 'openrouter', description: 'Multilingual support', color: '#7C3AED' },
-    { id: 'mistralai/mistral-small-3.1-24b-instruct', name: 'Mistral Small 3.1', provider: 'Mistral (OpenRouter)', providerKey: 'openrouter', description: 'Efficient with function calling (FREE)', color: '#FF6B35' },
-    { id: 'google/gemini-2.5-flash-preview', name: 'Gemini 2.5 Flash (OR)', provider: 'Google (OpenRouter)', providerKey: 'openrouter', description: 'Via OpenRouter', color: '#34A853' },
-    { id: 'x-ai/grok-3-mini-beta', name: 'Grok 3 Mini', provider: 'xAI (OpenRouter)', providerKey: 'openrouter', description: 'xAI reasoning model', color: '#000000' },
+
+    { id: 'deepseek/deepseek-v4-flash', name: 'DeepSeek V4 Flash', provider: 'DeepSeek (OpenRouter)', providerKey: 'openrouter', description: 'Fast MoE, 1M context, great value', color: '#00D4AA' },
+    { id: 'deepseek/deepseek-v4', name: 'DeepSeek V4', provider: 'DeepSeek (OpenRouter)', providerKey: 'openrouter', description: 'Near-frontier reasoning and coding', color: '#00B894' },
+    { id: 'z-ai/glm-5.2', name: 'GLM 5.2', provider: 'Z.ai (OpenRouter)', providerKey: 'openrouter', description: 'Strong open agentic and coding model', color: '#7C3AED' },
+    { id: 'meta-llama/llama-4-maverick', name: 'Llama 4 Maverick', provider: 'Meta (OpenRouter)', providerKey: 'openrouter', description: '400B MoE, multimodal', color: '#0668E1' },
+    { id: 'qwen/qwen3-32b', name: 'Qwen 3 32B', provider: 'Qwen (OpenRouter)', providerKey: 'openrouter', description: 'Multilingual open model', color: '#FF6B35' },
   ],
-  
+
   councilMembers: [
-    { id: 'gpt-5.1', name: 'GPT-5.1', model: 'gpt-5.1', provider: 'OpenAI Flagship', color: '#10B981' },
+    { id: 'gpt-5.3', name: 'GPT-5.3', model: 'gpt-5.3', provider: 'OpenAI Flagship', color: '#10B981' },
     { id: 'claude-sonnet-4-5', name: 'Claude Sonnet 4.5', model: 'claude-sonnet-4-5', provider: 'Anthropic', color: '#EA580C' },
-    { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', model: 'gemini-2.5-flash', provider: 'Google', color: '#34A853' },
+    { id: 'gemini-3-flash', name: 'Gemini 3 Flash', model: 'gemini-3-flash', provider: 'Google', color: '#34A853' },
   ],
   
   dxoRoles: [

--- a/backend/src/mockData.js
+++ b/backend/src/mockData.js
@@ -3,8 +3,8 @@
 export const mockCouncilResponses = {
   members: [
     {
-      id: 'gpt-5.1',
-      name: 'GPT-5.1',
+      id: 'gpt-5.3',
+      name: 'GPT-5.3',
       provider: 'OpenAI Flagship',
       confidence: 87,
       summary: 'Based on comprehensive analysis, I recommend a microservices architecture with containerization for optimal scalability and maintainability.',
@@ -26,7 +26,7 @@ export const mockCouncilResponses = {
     },
     {
       id: 'claude-opus',
-      name: 'Claude Opus 4.5',
+      name: 'Claude Opus 4.6',
       provider: 'Anthropic Flagship',
       confidence: 92,
       summary: 'I strongly advocate for a modular monolith approach initially, with clear domain boundaries that allow future microservices extraction.',
@@ -81,7 +81,7 @@ export const mockCouncilResponses = {
   ],
   chairman: {
     name: 'Chairman',
-    model: 'Claude Opus 4.5',
+    model: 'Claude Opus 4.6',
     finalDecision: `After synthesizing inputs from all council members, I present the following recommendation:
 
 ## Final Recommendation: Modular Monolith with Serverless Extensions
@@ -93,9 +93,9 @@ export const mockCouncilResponses = {
 - **Event-driven patterns** provide flexibility for future evolution
 
 ### Key Disagreements Addressed 🔄
-- **GPT-5.1** favors immediate microservices, but this adds complexity prematurely
+- **GPT-5.3** favors immediate microservices, but this adds complexity prematurely
 - **Gemini 3 Pro's** serverless approach is valuable for auxiliary functions, not core services
-- **Claude Opus 4.5's** modular monolith provides the best balance
+- **Claude Opus 4.6's** modular monolith provides the best balance
 
 ### Synthesized Architecture:
 1. **Core Platform**: Modular monolith with clear bounded contexts

--- a/frontend/src/components/AdversarialView.jsx
+++ b/frontend/src/components/AdversarialView.jsx
@@ -5,23 +5,23 @@ import { SaveShareButtons } from './SaveShareButtons';
 
 const defaultRoles = [
   { 
-    id: 'advocate', 
-    name: 'Advocate', 
-    model: 'gpt-5.1', 
+    id: 'advocate',
+    name: 'Advocate',
+    model: 'gpt-5.3',
     focus: 'Strong initial opinion',
     instructions: 'Provide your strongest, clearest opinion. Take a firm stance. Do not hedge. Present your reasoning in a structured way.'
   },
   { 
-    id: 'challenger', 
-    name: 'Challenger', 
-    model: 'gpt-5.1', 
+    id: 'challenger',
+    name: 'Challenger',
+    model: 'claude-opus-4-6',
     focus: 'Critique and attack reasoning',
     instructions: 'Critique the Advocate\'s argument. Identify logical flaws, missing evidence, weak assumptions, and alternative interpretations. Be adversarial, rigorous, and unsparing.'
   },
   { 
-    id: 'arbiter', 
-    name: 'Arbiter', 
-    model: 'gpt-5.1', 
+    id: 'arbiter',
+    name: 'Arbiter',
+    model: 'gpt-5.3',
     focus: 'Evaluate and synthesize',
     instructions: 'Evaluate both the Advocate\'s argument and the Challenger\'s critique. Identify which points hold up and synthesize the strongest possible final position.'
   },
@@ -46,7 +46,7 @@ function AdversarialRoleSelector({ roles, onRolesChange }) {
         setAvailableModels(data.availableModels || []);
         
         if (data.availableModels?.length && roles) {
-          const defaultModel = data.availableModels[0]?.id || 'gpt-5.1';
+          const defaultModel = data.availableModels[0]?.id || 'gpt-5.3';
           const updatedRoles = roles.map((role) => {
             const modelExists = data.availableModels.some(m => m.id === role.model);
             if (!modelExists) {

--- a/frontend/src/components/CouncilMemberSelector.jsx
+++ b/frontend/src/components/CouncilMemberSelector.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
 import { CheckSquare, Loader2, ChevronDown, ChevronUp } from 'lucide-react';
 
-const defaultSelectedMembers = ['gpt-5.1', 'claude-sonnet-4-5', 'gemini-2.5-flash'];
-const defaultChairman = 'gpt-5.1';
+const defaultSelectedMembers = ['gpt-5.3', 'claude-sonnet-4-5', 'gemini-3-flash'];
+const defaultChairman = 'gpt-5.3';
 
 export function CouncilMemberSelector({ selectedMembers, onSelectionChange, chairmanModel, onChairmanChange }) {
   const [availableModels, setAvailableModels] = useState([]);

--- a/frontend/src/components/DxORoleSelector.jsx
+++ b/frontend/src/components/DxORoleSelector.jsx
@@ -22,7 +22,7 @@ export function DxORoleSelector({ roles, onRolesChange }) {
         setAvailableModels(data.availableModels || []);
         
         if (data.availableModels?.length && roles) {
-          const defaultModel = data.availableModels[0]?.id || 'gpt-5.1';
+          const defaultModel = data.availableModels[0]?.id || 'gpt-5.3';
           const updatedRoles = roles.map((role, index) => {
             const modelExists = data.availableModels.some(m => m.id === role.model);
             if (!modelExists) {
@@ -51,7 +51,7 @@ export function DxORoleSelector({ roles, onRolesChange }) {
   };
 
   const addRole = () => {
-    const defaultModel = availableModels[0]?.id || 'gpt-5.1';
+    const defaultModel = availableModels[0]?.id || 'gpt-5.3';
     const newRole = {
       id: `role-${Date.now()}`,
       name: 'New Role',

--- a/frontend/src/components/DxOView.jsx
+++ b/frontend/src/components/DxOView.jsx
@@ -7,10 +7,10 @@ import { DxORoleSelector } from './DxORoleSelector';
 import { SaveShareButtons } from './SaveShareButtons';
 
 const defaultRoles = [
-  { id: 'lead', name: 'Lead Researcher', model: 'gpt-5.1', focus: 'Primary analysis and synthesis', instructions: 'Conduct thorough research analysis, identify key findings and patterns.' },
-  { id: 'reviewer', name: 'Critical Reviewer', model: 'gpt-4.1', focus: 'Identify gaps and weaknesses', instructions: 'Critically evaluate the research, identify methodological issues and limitations.' },
-  { id: 'expert', name: 'Domain Expert', model: 'o3-mini', focus: 'Deep domain knowledge', instructions: 'Provide specialized expertise and context from the relevant field.' },
-  { id: 'analyst', name: 'Data Analyst', model: 'gpt-5', focus: 'Quantitative reasoning', instructions: 'Focus on data, statistics, and quantitative aspects of the problem.' },
+  { id: 'lead', name: 'Lead Researcher', model: 'gpt-5.3', focus: 'Primary analysis and synthesis', instructions: 'Conduct thorough research analysis, identify key findings and patterns.' },
+  { id: 'reviewer', name: 'Critical Reviewer', model: 'claude-sonnet-4-5', focus: 'Identify gaps and weaknesses', instructions: 'Critically evaluate the research, identify methodological issues and limitations.' },
+  { id: 'expert', name: 'Domain Expert', model: 'gemini-3-pro', focus: 'Deep domain knowledge', instructions: 'Provide specialized expertise and context from the relevant field.' },
+  { id: 'analyst', name: 'Data Analyst', model: 'gpt-5.2', focus: 'Quantitative reasoning', instructions: 'Focus on data, statistics, and quantitative aspects of the problem.' },
 ];
 
 export function DxOView() {

--- a/replit.md
+++ b/replit.md
@@ -40,29 +40,24 @@ DeepR is an AI decision-making framework demo that showcases three LLM orchestra
 ## Multi-Provider LLM Support
 The app supports 4 LLM providers via **Replit AI Integrations** (no API keys required, charges billed to Replit credits):
 
-### OpenAI Models (12 models)
-- gpt-5.2, gpt-5.1, gpt-5, gpt-5-mini, gpt-5-nano
-- gpt-4.1, gpt-4.1-mini, gpt-4o, gpt-4o-mini
-- o4-mini, o3, o3-mini
+### OpenAI Models (5 models)
+- gpt-5.3 (flagship), gpt-5.2, gpt-5.1
+- gpt-5-mini, gpt-5-nano
 
-### Anthropic Claude Models (4 models)
-- claude-opus-4-5 (most capable)
+### Anthropic Claude Models (3 models)
+- claude-opus-4-6 (most capable)
 - claude-sonnet-4-5 (balanced)
 - claude-haiku-4-5 (fastest)
-- claude-opus-4-1
 
 ### Google Gemini Models (4 models)
-- gemini-3-pro-preview, gemini-3-flash-preview
+- gemini-3-pro, gemini-3-flash
 - gemini-2.5-pro, gemini-2.5-flash
 
-### OpenRouter Models (9+ models, access to 300+)
-- meta-llama/llama-4-maverick (FREE), meta-llama/llama-4-scout (FREE)
-- meta-llama/llama-3.3-70b-instruct
-- deepseek/deepseek-chat-v3-0324, deepseek/deepseek-r1
+### OpenRouter Models (5 open-source, access to 300+)
+- deepseek/deepseek-v4-flash, deepseek/deepseek-v4
+- z-ai/glm-5.2
+- meta-llama/llama-4-maverick
 - qwen/qwen3-32b
-- mistralai/mistral-small-3.1-24b-instruct (FREE)
-- google/gemini-2.5-flash-preview
-- x-ai/grok-3-mini-beta
 
 ## Running the Application
 The workflow runs both frontend and backend concurrently:


### PR DESCRIPTION
Refresh the model lists used by all three tabs (Council, DxO,
Adversarial) to currently available models that sit a version or two
behind the frontier, and add stronger open-source options.

- OpenAI: lead with GPT-5.3; drop legacy 4o/4.1/o3 entries
- Anthropic: Opus 4.6, Sonnet 4.5, Haiku 4.5
- Google: Gemini 3 Pro/Flash (GA ids) plus 2.5 Pro/Flash
- OpenRouter: add DeepSeek V4 Flash, DeepSeek V4, and GLM 5.2

Sync hardcoded frontend defaults, council members, default/chairman
models, mock demo labels, and docs (README, replit.md).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011tAs7Y5MAdmnR3TK2foHQB